### PR TITLE
fix docs

### DIFF
--- a/docs/docs/api/material-ui.md
+++ b/docs/docs/api/material-ui.md
@@ -144,7 +144,12 @@ interface SimpleFileUploadProps {
 ```jsx
 import { Switch } from 'formik-material-ui';
 
-<Field component={Switch} type="checkbox" name="switch" />;
+{({ values, handleChange }) => (
+  <Form>
+    <Field component={Switch} type="checkbox" name="initialValueProp" checked={values.initialValueProp} onChange={handleChange} />
+  </Form>
+)}
+
 ```
 
 #### [Material-UI Documentation](https://material-ui.com/api/switch/)


### PR DESCRIPTION
The documented way of adding a material-ui checkbox does not update / represent the state in initialValues correctly and the way Formik advise to handle multiple checkboxes with checked: [] doesn't work either. This is the solution.