### PR TITLE
[Docs] Autocomplete

### DIFF
--- a/docs/docs/api/material-ui.md
+++ b/docs/docs/api/material-ui.md
@@ -33,6 +33,7 @@ const options = [{ title: 'The Shawshank Redemption', year: 1994 }, ...]
   )}
 />;
 ```
+Note that, when overriding Autocomplete's `onChange`, you'll need to destructure Formik's params and then include a call to `setFieldValue`.
 
 _Note the manual inclusion of the error_
 


### PR DESCRIPTION
Warn the user when overriding Autocomplete onChange that they will need to call `setFieldValue`

Closes https://github.com/stackworx/formik-mui/issues/293
Reference https://github.com/stackworx/formik-mui/issues/267